### PR TITLE
use pre-built mdbook action to make deploy of website faster

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -22,12 +22,10 @@ jobs:
       MDBOOK_VERSION: 0.4.36
     steps:
       - uses: actions/checkout@v4
-      - name: Install mdBook
-        run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
-          rustup update
-          cargo install --version ${MDBOOK_VERSION} mdbook
-          cargo install mdbook-alerts
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
       - name: Install static-sitemap-cli
         run: npm install static-sitemap-cli
       - name: Setup Pages


### PR DESCRIPTION
This uses https://github.com/peaceiris/actions-mdbook in order to make actions faster.

This should save us on minutes a bit