### PR TITLE
install mdbook-alerts manually in workflow

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -26,6 +26,8 @@ jobs:
         uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: 'latest'
+      - name: Install mdBook preprocessors
+        run: cargo install mdbook-alerts
       - name: Install static-sitemap-cli
         run: npm install static-sitemap-cli
       - name: Setup Pages


### PR DESCRIPTION
After switching to a pre-built container in 6481df38e33207542f36f69b6589af14d78f1f47, the mdbook preprocessor won't work as it isn't installed.

This change installs it manually in the action