### PR TITLE
grab mdbook-alerts binary instead of building with cargo

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           mdbook-version: 'latest'
       - name: Install mdBook preprocessors
-        run: cargo install mdbook-alerts
+        run: wget -q https://github.com/lambdalisue/rs-mdbook-alerts/releases/download/v0.7.0/mdbook-alerts-x86_64-unknown-linux-gnu -O /usr/local/bin/mdbook-alerts
       - name: Install static-sitemap-cli
         run: npm install static-sitemap-cli
       - name: Setup Pages


### PR DESCRIPTION
This PR makes the mdbook workflow install the pre-built binary for `mdbook-alerts` instead of building with cargo.

This should drastically speed up the workflow