### PR TITLE
make mdbook-alerts executable and show version for debug info

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -27,7 +27,10 @@ jobs:
         with:
           mdbook-version: 'latest'
       - name: Install mdBook preprocessors
-        run: wget -q https://github.com/lambdalisue/rs-mdbook-alerts/releases/download/v0.7.0/mdbook-alerts-x86_64-unknown-linux-gnu -O /usr/local/bin/mdbook-alerts
+        run: |
+          wget -q https://github.com/lambdalisue/rs-mdbook-alerts/releases/download/v0.7.0/mdbook-alerts-x86_64-unknown-linux-gnu -O /usr/local/bin/mdbook-alerts
+          chmod +x /usr/local/bin/mdbook-alerts
+          mdbook-alerts --version
       - name: Install static-sitemap-cli
         run: npm install static-sitemap-cli
       - name: Setup Pages


### PR DESCRIPTION
The mdbook action currently installs the mdbook-alerts preprocessor from github releases and `mdbook build` does not complain about being unable to find the preprocessor.

It seems, though, that the docs don't render alerts properly 
![image](https://github.com/user-attachments/assets/0e3936a7-ddeb-4874-b082-9630d349fda8)

My theory is that this is because the binary isn't executable. 
This PR makes the binary executable and displays the version to make sure it can be found in the path correctly. 